### PR TITLE
Development

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,9 +5,13 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
     - name: Ensure setup-python works with "act"
+      if: matrix.platform != 'windows-latest'
       run: |
           if [ ! -f "/etc/lsb-release" ] ; then
             echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release

--- a/nix/steinbit.nix
+++ b/nix/steinbit.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     wheel
     pillow
     tqdm
-    magic
   ];
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ pillow>=7.0.0
 tqdm
 scikit-learn
 m2r2
-python-magic
 lasio

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,9 +40,6 @@ ignore_missing_imports = True
 [mypy-setuptools.*]
 ignore_missing_imports = True
 
-[mypy-magic.*]
-ignore_missing_imports = True
-
 [mypy-lasio.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ setup(
   author_email='henrik@rocktype.com',
   url='https://github.com/Rocktype/steinbit',
   keywords=['steinbit', 'qemscan'],
+  install_requires=[
+      'numpy', 'scipy', 'pandas',
+      'pillow>=7.0.0', 'tqdm',
+      'scikit-learn', 'lasio'],
   entry_points={
       'console_scripts': [
           'steinbit = steinbit.steinbit:main',

--- a/steinbit/create.py
+++ b/steinbit/create.py
@@ -11,7 +11,7 @@ from typing import Iterator
 import pandas as pd
 from PIL import Image
 from tqdm import tqdm
-import magic
+import mimetypes
 import lasio
 
 
@@ -46,8 +46,9 @@ class SteinbitCreate:
         """
         Append a single file to the frame
         """
-        mime = magic.detect_from_filename(filepath).mime_type
-        if not mime.startswith('image'):
+        mimetypes.init()
+        mime = mimetypes.guess_type(filepath)[0]
+        if mime and not mime.startswith('image'):
             frame = SteinbitCreate.read_las(filepath)
             if frame is None:
                 frame = pd.read_csv(filepath)


### PR DESCRIPTION
Closes #1

Python-magic-bin has a different API to python-magic, so Windows and Linux installs do not match up on either packages or APIs.

1. Replace libmagic with something cross-platform
2. Add a Windows runner to test